### PR TITLE
Fix Default Dataset Not Loading on Startup and Improve Prediction Display After Annotation Selection

### DIFF
--- a/tools/vis_tools/windows/main_window.py
+++ b/tools/vis_tools/windows/main_window.py
@@ -1,14 +1,14 @@
 import os
 import pickle
-import numpy as np
-from loguru import logger
-from utils import common
-from utils import gl_engine as gl
-from pcdet.datasets import PI3DET_Dataset
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QHBoxLayout, QComboBox, QPushButton, QFileDialog,\
                             QLabel, QLineEdit, QListWidget
+import numpy as np
+from pcdet.datasets import PI3DET_Dataset
+from loguru import logger
+from utils import common
+from utils import gl_engine as gl
 
 class CustomListWidget(QListWidget):
 
@@ -58,6 +58,8 @@ class MainWindow(QWidget):
         self.split_select_cbox.addItems([
             'training', 'validation'
         ])
+        # default selection
+        self.dataset_split = 'training'
 
         # load dataset button
         self.load_dataset_button = QPushButton('Load Dataset')
@@ -127,7 +129,7 @@ class MainWindow(QWidget):
         self.dataset = PI3DET_Dataset(
             dataset_cfg=dataset_cfg,
             class_names=['Car', 'Pedestrian'],
-            training=self.dataset_split == 'training',
+            training= (self.dataset_split == 'training'),
             root_path=dataset_cfg.DATA_PATH
         )
         self.frames_count = len(self.dataset)
@@ -203,7 +205,7 @@ class MainWindow(QWidget):
 
         if hasattr(self, 'predict_infos'):
             boxes_3d = self.predict_infos[self.sample_index]['boxes_lidar']
-            labels = self.predict_infos[self.sample_index]['pred_labels'][:, None] + 2
+            labels = self.predict_infos[self.sample_index]['pred_labels'][:, None] + 10
             boxes_3d = np.hstack([boxes_3d, labels])
             box_info = gl.create_boxes(bboxes_3d=boxes_3d)
             for box_item, l1_item, l2_item in zip(box_info['box_items'], box_info['l1_items'],\
@@ -228,6 +230,8 @@ class MainWindow(QWidget):
         f = open(file, 'rb')
         anno_list = pickle.load(f)
         self.predict_infos = anno_list
+        # show prediction after select annotation
+        self.show_sample()
 
     def show_sample(self):
         self.reset_viewer()


### PR DESCRIPTION
**1. Fix: Default Dataset Not Loading on Startup**
When the GUI first opens, and user click `load dataset` will throw an error:

`AttributeError: 'MainWindow' object has no attribute 'dataset_split'`

This is now resolved by ensuring `dataset_split` is properly initialized before calling load_dataset.

**2. Improvement: Display Predictions Immediately After Annotation 

Previously, after selecting an annotation, the predicted boxes were not displayed until additional user interaction ().
This update ensures that predictions (bounding boxes, etc.) are shown immediately upon annotation selection (`increment_index`, `decrement_index`, `goto_sample_index`, `on_frame_selected`, ...)

These changes improve the initial UX and make annotation review more seamless.